### PR TITLE
Jenkins machines need network restart after gateway down.

### DIFF
--- a/scripts/restartNetwork
+++ b/scripts/restartNetwork
@@ -1,0 +1,7 @@
+#!/bin/bash
+x=`ping -c1 google.com 2>&1 | grep unknown`
+if [ ! "$x" = "" ]; then
+        echo "It's down!! Attempting to restart."
+        sudo service network-manager restart
+        #sudo ifconfig eth0 down && sudo ifconfig eth0 up
+fi


### PR DESCRIPTION
Add the following line to /etc/crontab. Change the */10 to whatever increment you want to have this script run in minutes. It's currently set to run /usr/local/bin/check_netowork every 10 minutes.
Code:


*/10 * * * * root /usr/local/bin/check_network
