### PR TITLE
JENKINS-90 Store CSS file for job description externally.

### DIFF
--- a/ansible_jenkins/roles/emulator/tasks/main.yml
+++ b/ansible_jenkins/roles/emulator/tasks/main.yml
@@ -33,13 +33,16 @@
     path: "{{ android_sdk_license_dir }}"
     state: directory
     recurse: yes
+  become_user: catroid
 
 - name: Create the android sdk licence file.
   copy:
     content: "\n8933bad161af4178b1185d1a37fbf41ea5269c55\n"
     dest: "{{ android_sdk_license_dir }}/android-sdk-license"
+  become_user: catroid
 
 - name: Create the android sdk preview licence file.
   copy:
     content: "\n84831b9409646a918e30573bab4c9c91346d8abd\n"
     dest: "{{ android_sdk_license_dir }}/android-sdk-preview-license"
+  become_user: catroid

--- a/ansible_jenkins/roles/master/tasks/main.yml
+++ b/ansible_jenkins/roles/master/tasks/main.yml
@@ -32,6 +32,14 @@
   environment:
     JENKINS_HOME: "{{ jenkins_home }}"
 
+  # Jobs can use a shared style sheet, see https://confluence.catrob.at/x/SYFYAQ
+- name: Place a link to the job style in the user content directory.
+  file:
+    src: "{{ catroid_user_home }}/Jenkins/css/job_styles.css"
+    dest: "{{ jenkins_home }}/userContent/job_styles.css"
+    state: link
+  become_user: jenkins
+
 - name: Change Jenkins Defaults
   ini_file:
     section: null

--- a/css/job_styles.css
+++ b/css/job_styles.css
@@ -1,0 +1,14 @@
+.cat-info {
+    background-color: #ddffdd;
+    border-left: 6px solid #4CAF50;
+}
+
+.cat-note {
+    background-color: #ffffcc;
+    border-left: 6px solid #ffeb3b;
+}
+
+.cat-warning {
+    background-color: #ffdddd;
+    border-left: 6px solid #f44336;
+}


### PR DESCRIPTION
This avoids of copy-pasting the style sheets in the job description.
As a result maintenance of the style sheets is easier.
There is only one single source of truth.