### PR TITLE
JENKINS-182: JOB-DSL: AndroidJobBuilder fails

### DIFF
--- a/job_dsl/src/main/lib/AndroidJobBuilder.groovy
+++ b/job_dsl/src/main/lib/AndroidJobBuilder.groovy
@@ -42,6 +42,7 @@ class AndroidJobBuilder extends JobBuilder {
                 osVersion("android-${p.androidApi}")
                 screenDensity(p.screenDensity)
                 screenResolution(p.screenResolution)
+                deviceDefinition('')
                 deviceLocale(p.deviceLocale)
                 sdCardSize(p.sdCardSize)
                 targetAbi(p.targetAbi)


### PR DESCRIPTION
Due to a new config option (deviceDevfinition) in
the android emulator plugin the config fails.
Even though the value is optional in the plugin,
it is required in the job-dsl to set the value to empty.