### PR TITLE
JENKINS-222: Pipeline does not support concurrentBuild

### DIFF
--- a/job_dsl/src/main/lib/JobBuilder.groovy
+++ b/job_dsl/src/main/lib/JobBuilder.groovy
@@ -89,7 +89,6 @@ $bulletPointsStr    </ul>\n</div>"""
     }
 
     void nightly(String schedule='H 0 * * *') {
-        job.concurrentBuild(false)
         job.triggers {
             cron(schedule)
         }

--- a/job_dsl/src/main/resources/jobs/internal.groovy
+++ b/job_dsl/src/main/resources/jobs/internal.groovy
@@ -9,6 +9,7 @@ internal.job("SeedJob") {
     label('master')
     git(repo: 'https://github.com/Catrobat/Jenkins.git', branch: 'master')
     continuous()
+    concurrentBuild(false)
     nightly('H 23 * * *') // run the job before all other nightlies
     shell('cp configs/log_parser_rules.groovy $JENKINS_HOME/')
     steps {


### PR DESCRIPTION
Remove call from generic JobBuilder, where it was used inside the nightly block.
First there is no need to imply concurrentBuild(false) if a jobs shall also run on a daily schedule. Second by default a job is not marked as concurrent if no call to concurrentBuild is done.
Still explicitly state the line in the SeedJob, as it was the only freestyle-job using nightly and the job which definitely will cause troubles if called concurrently, should the default behavior change.