### PR TITLE
[JENKINS-198] Revive nightly builds

### DIFF
--- a/job_dsl/src/main/resources/jobs/jenkinsfiles/nightly_trigger.jenkinsfile
+++ b/job_dsl/src/main/resources/jobs/jenkinsfiles/nightly_trigger.jenkinsfile
@@ -1,0 +1,31 @@
+#!groovy
+
+/* 
+   Nightly Trigger Job
+   - Catroid Dev
+   - Paintroid Dev
+   - Build-Standalone 
+*/
+
+pipeline {
+    agent none
+
+    stages {
+
+        stage ('Trigger') {
+            
+            steps {         
+            
+                // https://jenkins.catrob.at/job/Catroid/job/develop/
+                build(job: 'Catroid/develop', wait: false)
+
+                // https://jenkins.catrob.at/job/Paintroid/job/develop/
+                build(job: 'Paintroid/develop', wait: false)
+
+                // https://jenkins.catrob.at/job/Build-Standalone/
+                build(job: 'Build-Standalone', wait: false)
+            
+            }    
+        }
+    }
+}

--- a/job_dsl/src/main/resources/jobs/nightly.groovy
+++ b/job_dsl/src/main/resources/jobs/nightly.groovy
@@ -1,0 +1,12 @@
+def pipelinescript = new JobsBuilder(this).pipelineFromScript()
+
+pipelinescript.job("Nightly-Trigger") {
+    htmlDescription(['Nightly trigger job for Catroid/dev, Paintroid/dev and Build-Standalone.'])
+
+    jenkinsUsersPermissions(Permission.JobRead, Permission.JobBuild, Permission.JobCancel)
+    anonymousUsersPermissions(Permission.JobRead) // allow anonymous users to see the results of PRs to fix their issues
+
+    nightly()
+
+    jenkinsfileScriptPath('job_dsl/src/main/resources/jobs/jenkinsfiles/nightly_trigger.jenkinsfile')
+}


### PR DESCRIPTION
pipeline trigger job for paintroid/dev, catroid/dev and stand-alone regarding to issue [[JENKINS-198]](https://jira.catrob.at/browse/JENKINS-198).