### PR TITLE
JENKINS-161: Remove the currently unused mask-passwords plugin

### DIFF
--- a/ansible_jenkins/roles/master/tasks/main.yml
+++ b/ansible_jenkins/roles/master/tasks/main.yml
@@ -105,7 +105,6 @@
     - job-dsl                   # Support for a DSL to describe jobs
     - jobConfigHistory          # diff changes in job config
     - lockable-resources        # Locking resources on node (eg: manipulate android SDK)
-    - mask-passwords            # Hides passwords in the job log
     - parallel-test-executor    # Distribute tests onto multiple nodes for better performance
     - pmd                       # Collects PMD static analysis results
     - rebuild                   # adds a rebuild button to jobs

--- a/job_dsl/src/main/lib/FreeStyleJobBuilder.groovy
+++ b/job_dsl/src/main/lib/FreeStyleJobBuilder.groovy
@@ -11,7 +11,6 @@ class FreeStyleJobBuilder extends JobBuilder {
         jdk('(System)')
         job.wrappers {
             timestamps()
-            maskPasswords()
         }
     }
 


### PR DESCRIPTION
The mask-passwords plugin is currently activated via the JobDSL for all Freestyle-Jobs. But there is only one global configuration entry currently available (PWS), where i could not find a reference or a masked password in any of the FreeStyle-Jobs.
So the configuration shall be removed, to be able to remove the plugin itself.