### PR TITLE
JENKINS-223 Activate workspace permission for Jenkins-Users for Catroid.

### DIFF
--- a/job_dsl/src/main/resources/jobs/catroid.groovy
+++ b/job_dsl/src/main/resources/jobs/catroid.groovy
@@ -7,7 +7,9 @@ catroidorg.job("Catroid") {
                      'This job runs the Pipeline defined in the Jenkinsfile inside of the repository.',
                      'The Pipeline should run the code analyisis, the unit and device tests.'])
 
-    jenkinsUsersPermissions(Permission.JobRead, Permission.JobBuild, Permission.JobCancel)
+    // Workspace rights are needed to show the java files for code coverage.
+    jenkinsUsersPermissions(Permission.JobRead, Permission.JobBuild, Permission.JobCancel, Permission.JobWorkspace)
+
     anonymousUsersPermissions(Permission.JobRead) // allow anonymous users to see the results of PRs to fix their issues
 
     gitHubOrganization()


### PR DESCRIPTION
That way Jenkins-Users will be able to check the java files in the code coverage results.