### PR TITLE
Fixes typo.

### DIFF
--- a/job_dsl/src/main/lib/JobBuilder.groovy
+++ b/job_dsl/src/main/lib/JobBuilder.groovy
@@ -73,7 +73,7 @@ $bulletPointsStr    </ul>\n</div>"""
     }
 
     void anonymousUsersPermissions(Permission... permissions_) {
-        permissions('Anonymous', *permissions_)
+        permissions('anonymous', *permissions_)
     }
 
     void jenkinsUsersPermissions(Permission... permissions_) {


### PR DESCRIPTION
I checked the configuration xml files.
The anonymous users starts with a lower 'a' and not a capital one.