### PR TITLE
JENKINS-209: Build-Standalone: Migrate to pipeline

### DIFF
--- a/job_dsl/src/main/lib/PiplineJobBuilder.groovy
+++ b/job_dsl/src/main/lib/PiplineJobBuilder.groovy
@@ -133,6 +133,21 @@ class PiplineJobBuilder extends JobBuilder {
         }
     }
 
+    // Since JobDSL version 1.70 the authenticationToken value is WRONGLY marked as deprecated.
+    // https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-170
+    // Furthermore it is not only marked as deprecated, the current implementation just ignores
+    // the value.
+    // It will be usable in the next release again, please see the corresponding discussion:
+    // https://issues.jenkins-ci.org/browse/JENKINS-31832
+    // Until then, we use the configure block to provide the functionality.
+    // If JobDSL version 1.71 is out (and contains the fix) this block can simply be removed and
+    // the 'upstream-implemenation' will be used as they have the same signature.
+    void authenticationToken(def token) {
+        configure { Node project ->
+            project / authToken(token)
+        }
+    }
+
     void importJenkinsfileFromWS(String jenkinsfilePath) {
         job.definition {
             cps {

--- a/job_dsl/src/main/resources/jobs/catroid.groovy
+++ b/job_dsl/src/main/resources/jobs/catroid.groovy
@@ -1,6 +1,6 @@
 def catroid = new JobsBuilder(this).android({new CatroidData()}).folderAndView('Catroid-Legacy')
 def catroidorg = new JobsBuilder(this).gitHubOrganization({new CatroidData()})
-def catroidroot = new JobsBuilder(this).android({new CatroidData()})
+def catroidroot = new JobsBuilder(this).pipeline({new CatroidData()})
 
 catroidorg.job("Catroid") {
     htmlDescription(['Job is automatically started on a new commit or a new/updated pull request created on github.',
@@ -136,8 +136,6 @@ catroidroot.job("Build-Standalone") {
     // !! DO NOT give Anonymous-Users read permission, otherwise the upload-token would be spoiled
     jenkinsUsersPermissions(Permission.JobRead)
 
-    label('Standalone')
-
     parameters {
         stringParam('DOWNLOAD', 'https://share.catrob.at/pocketcode/download/821.catrobat', 'Enter the Project ID you want to build as standalone')
         stringParam('SUFFIX', 'standalone', '')
@@ -156,58 +154,5 @@ catroidroot.job("Build-Standalone") {
     def token = GLOBAL_STANDALONE_AUTH_TOKEN
 
     authenticationToken(token)
-    buildName('#${DOWNLOAD}')
-    git(branch: 'master')
-
-    failBuildAfterNoActivity('600')
-
-    job.steps {
-        shell {
-            command('''#!/bin/sh
-SLEEP_TIME=5
-RETRIES=5
-
-HTTP_STATUS_OK=200
-HTTP_STATUS_INVALID_FILE_UPLOAD=528
-
-## check if program is downloadable from web
-## If we can't load it, we retry it ${RETRIES} times
-## On a 528 status (invalid upload), we return 200 which
-## should get interpreted as UNSTABLE build
-while true; do
-    HTTP_STATUS=`curl --write-out %{http_code} --silent --output /dev/null "${DOWNLOAD}"`
-
-    if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_OK} ]; then
-        break
-    fi
-
-
-    RETRIES=$((RETRIES-1))
-    if [ ${RETRIES} -eq 0 ]; then
-        if [ ${HTTP_STATUS} -eq ${HTTP_STATUS_INVALID_FILE_UPLOAD} ]; then
-            echo "Uploaded file seems to be invalid, request to '${DOWNLOAD}' returned HTTP Status ${HTTP_STATUS}"
-            exit 200
-        else
-            echo "Could not download '${DOWNLOAD}', giving up!"
-            exit 1
-        fi
-    fi
-
-    echo "Could not retrieve '${DOWNLOAD}' (HTTP Status ${HTTP_STATUS}), sleep for ${SLEEP_TIME}s and retry a maximum of ${RETRIES} times"
-    sleep ${SLEEP_TIME}
-done
-
-./gradlew -Pdownload="${DOWNLOAD}" -Papk_generator_enabled=true -Psuffix="${SUFFIX}" assembleStandaloneDebug
-
-## +x, otherwise we would spoil the upload token
-set +x
-curl -X POST -k -F upload=@./''' + projectData.standaloneApk + ''' "${UPLOAD}"
-''')
-            unstableReturn(200)
-        }
-    }
-
-    archiveArtifacts(projectData.standaloneApk, true)
-
-    notifications(true)
+    git(branch: 'master', jenkinsfile: 'Jenkinsfile.BuildStandalone')
 }


### PR DESCRIPTION
Changes the current FreeStyle-Job Build-Standalone to a Pipeline-job which uses the already existent Jenkinsfile.BuildStandalone inside the catroid-repository.