### PR TITLE
JENKINS-234 - JobDSL: Port SeedJob to pipeline

### DIFF
--- a/jenkinsfile.seedjob
+++ b/jenkinsfile.seedjob
@@ -1,0 +1,15 @@
+pipeline {
+    agent { label "master"}
+    stages{
+        stage('init'){
+            steps{
+                script{
+                    stage("create Jobs"){
+                            jobDsl targets:['job_dsl/src/main/resources/jobs/*.groovy'].join('\n'),
+							additionalClasspath: 'job_dsl/src/main/lib/'
+                   }
+                }
+            }
+        }
+    }
+}

--- a/job_dsl/src/main/lib/JobsBuilder.groovy
+++ b/job_dsl/src/main/lib/JobsBuilder.groovy
@@ -15,7 +15,7 @@ class JobsBuilder {
         this.dslFactory = dslFactory
         this.dataCreator = dataCreator?.clone() ?: { null }
         this.folder = folder
-        this.jobBuilderClass = jobBuilderClass ?: FreeStyleJobBuilder.class
+        this.jobBuilderClass = jobBuilderClass ?: PiplineJobBuilder.class
     }
 
     JobsBuilder android(def dataCreator) {
@@ -52,11 +52,11 @@ class JobsBuilder {
 
     JobsBuilder job(String name, Closure closure) {
         if (MultibranchPipelineJobBuilder.class.isAssignableFrom(this.jobBuilderClass)) {
-            job(dslFactory.multibranchPipelineJob(name), closure)
+            job(dslFactory.multibranchPipelineJob(folder + name), closure)
         } else if (PiplineJobBuilder.class.isAssignableFrom(this.jobBuilderClass)) {
-            job(dslFactory.pipelineJob(name), closure)
+            job(dslFactory.pipelineJob(folder + name), closure)
         } else {
-            job(dslFactory.freeStyleJob(folder + name), closure)
+            assert false //only pipeline jobs are supported
         }
         this
     }

--- a/job_dsl/src/main/resources/jobs/internal.groovy
+++ b/job_dsl/src/main/resources/jobs/internal.groovy
@@ -1,27 +1,14 @@
 // The file should not be named jenkins.groovy as that leads to a warning as there
 // is already a jenkins package.
-def internal = new JobsBuilder(this).folder('Jenkins', {})
+def internal = new JobsBuilder(this).folderAndView('Jenkins', {})
 
 internal.job("SeedJob") {
     htmlDescription(['Seed job to create all other jobs.'])
 
     jenkinsUsersPermissions()
-    label('master')
-    git(repo: 'https://github.com/Catrobat/Jenkins.git', branch: 'master')
-    continuous()
-    concurrentBuild(false)
-    nightly('H 23 * * *') // run the job before all other nightlies
-    shell('cp configs/log_parser_rules.groovy $JENKINS_HOME/')
-    steps {
-        jobDsl {
-            additionalClasspath('job_dsl/src/main/lib/')
-            targets('job_dsl/src/main/resources/jobs/*.groovy')
-            failOnMissingPlugin(true)
-            removedJobAction('DELETE')
-            removedViewAction('DELETE')
-            unstableOnDeprecation(true)
-        }
-    }
+    git(repo: 'https://github.com/Catrobat/Jenkins.git', branch: 'master', jenkinsfile: 'jenkinsfile.seedjob')
+    configure { it / definition / lightweight(true)}
 
     notifications()
 }
+


### PR DESCRIPTION
The SeedJob is the last non-pipeline job inside the JobSDL. To harmonize the jobs and to reduce the need to support freestyle and pipeline jobs inside the JobDSL, the SeedJob shall be migrated to a pipeline job (job_dsl/src/main/resources/jobs/internal.groovy).