### PR TITLE
JENKINS-284 Fix options/triggers for seed job.

### DIFF
--- a/jenkinsfile.seedjob
+++ b/jenkinsfile.seedjob
@@ -1,15 +1,6 @@
 pipeline {
     agent { label "master"}
 
-    triggers{
-       cron('H 23 * * *') // run the job before all other nightlies
-       pollSCM('H/5 * * * *')
-    }
-
-    options {
-        disableConcurrentBuilds()
-    }
-
     stages{
         stage('init'){
             steps{

--- a/job_dsl/src/main/resources/jobs/internal.groovy
+++ b/job_dsl/src/main/resources/jobs/internal.groovy
@@ -6,5 +6,8 @@ internal.job("SeedJob") {
     htmlDescription(['Seed job to create all other jobs.'])
 
     jenkinsUsersPermissions()
+    continuous()
+    concurrentBuild(false)
+    nightly('H 23 * * *') // run the job before all other nightlies
     git(repo: 'https://github.com/Catrobat/Jenkins.git', branch: 'master', jenkinsfile: 'jenkinsfile.seedjob')
 }


### PR DESCRIPTION
The triggers/options inside the Jenkinsfile did not work for the seed job.
Maybe this is due the job being a pipeline job and not a multibranch job.
A fix is to move these settings directly to the job.