### PR TITLE
JENKINS-286 Build the seed job every Sunday before the nightlies.

### DIFF
--- a/job_dsl/src/main/resources/jobs/internal.groovy
+++ b/job_dsl/src/main/resources/jobs/internal.groovy
@@ -8,6 +8,12 @@ internal.job("SeedJob") {
     jenkinsUsersPermissions()
     continuous()
     concurrentBuild(false)
-    nightly('H 23 * * *') // run the job before all other nightlies
+
+    // Run the job every Sunday before the nightlies.
+    // The job should not run as nightly itself. Otherwise multibranch jobs would
+    // start scanning the branches and rebuilding everying on changes.
+    // Irrespective of the settings for them.
+    nightly('H 23 * * 0')
+
     git(repo: 'https://github.com/Catrobat/Jenkins.git', branch: 'master', jenkinsfile: 'jenkinsfile.seedjob')
 }


### PR DESCRIPTION
When the seed job is build the multibranch jobs start scanning the branches
for changes, potentially leading to rebuilds.

When this scanning is performed should depend on the settings of the multibranch
job and not the seed job.
Running the seed job once per week strikes a trade-off between clean job
configurations and interaction with the multibranch jobs.